### PR TITLE
Fedidocs.org -> fedidevs.org

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-fedidocs.org
+fedidevs.org


### PR DESCRIPTION
Changed the DNS CNAME for fedidevs.org to point to the fedidocs GitHub pages 🤞🏻 (if you check via `dig` it should show the same as fedidocs, followed the GH pages custom domain instructions)