### PR TITLE
Updates to Mastodon documentation.

### DIFF
--- a/docs/projects/mastodon/activities/announce.md
+++ b/docs/projects/mastodon/activities/announce.md
@@ -1,0 +1,5 @@
+---
+title: Announce
+---
+
+Transformed into a boost on a `Status`

--- a/docs/projects/mastodon/activities/delete.md
+++ b/docs/projects/mastodon/activities/delete.md
@@ -1,0 +1,5 @@
+---
+title: Delete
+---
+
+Removes a `Status` from the database

--- a/docs/projects/mastodon/activities/flag.md
+++ b/docs/projects/mastodon/activities/flag.md
@@ -1,0 +1,5 @@
+---
+title: Flag
+---
+
+Transformed into a report to the moderation team.

--- a/docs/projects/mastodon/activities/like.md
+++ b/docs/projects/mastodon/activities/like.md
@@ -1,0 +1,5 @@
+---
+title: Like
+---
+
+Transformed into a favorite on a `Status`.

--- a/docs/projects/mastodon/activities/undo.md
+++ b/docs/projects/mastodon/activities/undo.md
@@ -1,0 +1,5 @@
+---
+title: Undo
+---
+
+Undo a previous [Like](like.md) or [Announce](announce.md).

--- a/docs/projects/mastodon/activities/update.md
+++ b/docs/projects/mastodon/activities/update.md
@@ -1,0 +1,5 @@
+---
+title: Update
+---
+
+Refresh vote count on a poll `Status`. Edit statuses when the updated timestamp is present (>= Mastodon 3.5.0).

--- a/docs/projects/mastodon/index.md
+++ b/docs/projects/mastodon/index.md
@@ -10,3 +10,20 @@ Mastodon is a Fediverse microblogging platform.
 ## Official documentation
 
 Mastodon has quite detailed documentation of their use of ActivityPub at [docs.joinmastodon.org](https://docs.joinmastodon.org/spec/activitypub/). For additional information visit there.
+
+## Overview
+
+Mastodon stores little or no ActivityPub information directly in its databases. Incoming [Activities](/category/activities-5) are converted into Mastodon-specific data structures like `Status` and `Account`. ActivityPub Activities (primarily [Note](note.md)) are converted into a `Status` and an Actor is represented by an `Account`. An ActivityPub `Question` is converted into a special kind of poll `Status`.
+
+Mastodon does not support the ActivityPub client to server (C2S) API. It uses a Mastodon-specific API for client access and administration.
+
+### Inbox
+
+Activities may be posted to the Mastodon inbox network endpoint, but not read from it. There is no actual inbox data structure in the Mastodon implementation. Mastodon represents this type of data as *timelines*, which are conceptually similar to the ActivityPub `OrderedCollection`.
+
+Actor-specific inbox endpoints are supported and there is a instance-level shared inbox. Posts to the inbox are authenticated using HTTP Signatures.
+
+### Outbox
+
+A partial list of an Actor's Activities can be read from the outbox network endpoint. The outbox is read-only. When read, the outbox contents will be filtered according to the credentials of the requester and will only contain Activities Mastodon is able to reconstruct from its internal data.
+


### PR DESCRIPTION
I added some information to the Mastodon index page and added front matter to some of the activities.

I didn't know how to properly link to the Mastodon Activities category from the Mastodon index page. I currently have a link there, but it appears to be a dynamically-generated category URL.